### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-07
+
+### 🔔 Changed
+
+- Require Go 1.25.0 by @powerman in [7859a7e]
+
+### 📦️ Dependencies
+
+- **(deps)** Bump go.abhg.dev/goldmark/mermaid from 0.5.0 to 0.6.0 by @dependabot[bot] in [#12]
+- **(deps)** Upgrade by @powerman in [4074ccd]
+
+[0.2.0]: https://github.com/powerman/goldmark-obsidian/compare/v0.1.4..v0.2.0
+[#12]: https://github.com/powerman/goldmark-obsidian/pull/12
+[4074ccd]: https://github.com/powerman/goldmark-obsidian/commit/4074ccd053f62e6950d2f4137dc47bf5874ff26e
+[7859a7e]: https://github.com/powerman/goldmark-obsidian/commit/7859a7ef359d9f7e63f82d1e9dcce8d8015ae9e6
+
 ## [0.1.4] - 2025-08-17
 
 [0.1.4]: https://github.com/powerman/goldmark-obsidian/compare/v0.1.3..v0.1.4


### PR DESCRIPTION

### 🔔 Changed

- Require Go 1.25.0 by @powerman in [7859a7e]

### 📦️ Dependencies

- **(deps)** Bump go.abhg.dev/goldmark/mermaid from 0.5.0 to 0.6.0 by @dependabot[bot] in [#12]
- **(deps)** Upgrade by @powerman in [4074ccd]

[0.2.0]: https://github.com/powerman/goldmark-obsidian/compare/v0.1.4..v0.2.0
[#12]: https://github.com/powerman/goldmark-obsidian/pull/12
[4074ccd]: https://github.com/powerman/goldmark-obsidian/commit/4074ccd053f62e6950d2f4137dc47bf5874ff26e
[7859a7e]: https://github.com/powerman/goldmark-obsidian/commit/7859a7ef359d9f7e63f82d1e9dcce8d8015ae9e6